### PR TITLE
[kanban] bug: #28, allow dropping cards into empty columns

### DIFF
--- a/src/components/Droppable.tsx
+++ b/src/components/Droppable.tsx
@@ -1,36 +1,42 @@
 "use client";
 
-import React from 'react'
-import { useDroppable } from '@dnd-kit/core'
-import { rectSortingStrategy, SortableContext } from '@dnd-kit/sortable'
+import React from "react";
+import { useDroppable } from "@dnd-kit/core";
+import { rectSortingStrategy, SortableContext } from "@dnd-kit/sortable";
 
-import SortableItem from './SortableItem'
-import type { CardData } from '@/types/card'
+import SortableItem from "./SortableItem";
+import type { CardData } from "@/types/card";
 
 type Props = {
-  id: string
-  items: CardData[]
-  onDelete?: (id: string, groupId: string) => void
-  onEdit?: (card: CardData, groupId: string) => void
-}
+  id: string;
+  items: CardData[];
+  onDelete?: (id: string, groupId: string) => void;
+  onEdit?: (card: CardData, groupId: string) => void;
+};
 
 const Droppable: React.FC<Props> = ({ id, items, onDelete, onEdit }) => {
-  const { setNodeRef } = useDroppable({ id })
+  const { setNodeRef } = useDroppable({ id });
 
   return (
     <SortableContext id={id} items={items} strategy={rectSortingStrategy}>
-      <div  ref={setNodeRef} className="flex flex-col gap-3 w-full">
-        {items.map((card) => (
-          <SortableItem
-            key={card.id}
-            card={card}
-            onDelete={(cardId) => onDelete?.(cardId, id)}
-            onEdit={(cardData) => onEdit?.(cardData, id)}
-          />
-        ))}
+      <div ref={setNodeRef} className="flex flex-col gap-3 w-full min-h-[60px]">
+        {items.length > 0 ? (
+          items.map((card) => (
+            <SortableItem
+              key={card.id}
+              card={card}
+              onDelete={(cardId) => onDelete?.(cardId, id)}
+              onEdit={(cardData) => onEdit?.(cardData, id)}
+            />
+          ))
+        ) : (
+          <div className="border border-dashed border-gray-300 p-3 text-center text-gray-400 text-sm rounded">
+            여기에 카드를 드롭하세요
+          </div>
+        )}
       </div>
     </SortableContext>
-  )
-}
+  );
+};
 
-export default Droppable
+export default Droppable;


### PR DESCRIPTION
### Changes
- 컬럼에 카드가 하나도 없는 경우에도 Droppable 영역이 렌더링되도록 조건부 UI 추가
- Droppable.tsx에 items.length === 0일 때 안내 메시지 및 최소 높이 영역(min-h-[60px]) 추가
- DnD-kit이 빈 컬럼을 유효한 드롭 타겟으로 인식하도록 개선

### Preview
- 이제 카드가 없는 컬럼에도 다른 컬럼에서 드래그한 카드를 드롭할 수 있습니다.
- 아래는 빈 컬럼에 카드 드롭이 가능한 예시입니다:
![스크린샷 2025-05-30 165609](https://github.com/user-attachments/assets/ad86e5f0-046e-4a89-b3c9-8db0c1fe8068)
